### PR TITLE
fix: The theme color does not take effect on the login page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,6 +7,8 @@
 </template>
 
 <script>
+import { updateTheme } from '@ant-design-vue/pro-layout'
+import defaultSettings from '@/config/defaultSettings'
 import { domTitle, setDocumentTitle } from '@/utils/domUtil'
 import { i18nRender } from '@/locales'
 
@@ -22,6 +24,13 @@ export default {
       title && (setDocumentTitle(`${i18nRender(title)} - ${domTitle}`))
 
       return this.$i18n.getLocaleMessage(this.$store.getters.lang).antLocale
+    }
+  },
+  created () {
+    // first update color
+    // TIPS: THEME COLOR HANDLER!! PLEASE CHECK THAT!!
+    if (process.env.NODE_ENV !== 'production' || process.env.VUE_APP_PREVIEW === 'true') {
+      updateTheme(defaultSettings.primaryColor)
     }
   }
 }

--- a/src/layouts/BasicLayout.vue
+++ b/src/layouts/BasicLayout.vue
@@ -53,7 +53,7 @@
 </template>
 
 <script>
-import { SettingDrawer, updateTheme } from '@ant-design-vue/pro-layout'
+import { SettingDrawer } from '@ant-design-vue/pro-layout'
 import { i18nRender } from '@/locales'
 import { mapState } from 'vuex'
 import { CONTENT_WIDTH_TYPE, SIDEBAR_TYPE, TOGGLE_MOBILE_TYPE } from '@/store/mutation-types'
@@ -132,12 +132,6 @@ export default {
           this.collapsed = !this.collapsed
         }, 16)
       })
-    }
-
-    // first update color
-    // TIPS: THEME COLOR HANDLER!! PLEASE CHECK THAT!!
-    if (process.env.NODE_ENV !== 'production' || process.env.VUE_APP_PREVIEW === 'true') {
-      updateTheme(this.settings.primaryColor)
     }
   },
   methods: {


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!


### 这个变动的性质是

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 文档改进
- [ ] 组件样式改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 描述相关需求的来源。
> 2. 要解决的问题。
> 3. 相关的 issue 讨论链接。
    Related issue https://github.com/vueComponent/ant-design-vue-pro/issues/1419

### 实现方案和 API（非新功能可选）

> 原有 @ant-design-vue/pro-layout 的 updateTheme 在 BasicLayout 中首次调用，而 Login.vue 不在 BasicLayout 下，故未能触发主题色更新

### 对用户的影响和可能的风险（非新功能可选）

> 1. 无影响，只是将 BasicLayout 执行的片段移动到了 App.vue 中

### Changelog 描述（非新功能可选）

> 1. fix: The theme color does not take effect on the login page
> 2. 修复主题色首屏在登录页未能生效缺陷

### 请求合并前的自查清单

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [x] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。